### PR TITLE
test: Fix to pass unit tests

### DIFF
--- a/closer_test.go
+++ b/closer_test.go
@@ -26,9 +26,9 @@ func TestCloseWithErrCapture(t *testing.T) {
 			actualErr = pkgErrors.New("already present")
 
 			m := &closerMock{ReturnError: expectedErr}
-			defer CloseWithErrCapture(m, &actualErr)
+			CloseWithErrCapture(m, &actualErr)
 
-			So(m.CloseCalled, ShouldEqual, 0)
+			So(m.CloseCalled, ShouldEqual, 1)
 			So(actualErr, ShouldBeError, "already present")
 		})
 

--- a/closer_test.go
+++ b/closer_test.go
@@ -28,7 +28,7 @@ func TestCloseWithErrCapture(t *testing.T) {
 			m := &closerMock{ReturnError: expectedErr}
 			defer CloseWithErrCapture(m, &actualErr)
 
-			So(m.CloseCalled, ShouldEqual, 1)
+			So(m.CloseCalled, ShouldEqual, 0)
 			So(actualErr, ShouldBeError, "already present")
 		})
 


### PR DESCRIPTION
테스트가 깨져 수정하였습니다. ~에러가 있을 경우 close 는 호출되지 않아야 하는 로직 확인했습니다.~

UPDATED: 
> 다만 에러가 있을 경우엔 Close가 호출되지 않는 것이 아니라, Close는 언제나 호출되지만 capture에 이미 에러가 있을 땐 Close로 인한 에러를 덮어쓰지 않는 것이 맞습니다. https://github.com/therne/errorist/pull/1#discussion_r468394398