### PR TITLE
docs: Make readme smoother

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,18 +4,18 @@
 [![Godoc Reference](http://img.shields.io/badge/godoc-reference-5272B4.svg?style=for-the-badge)](https://pkg.go.dev/github.com/therne/errorist)
 ![MIT License Badge](https://img.shields.io/github/license/therne/errorist?style=for-the-badge)
 
-Package errorist provides useful error handling utilities, including ones recommended in
+Package errorist provides useful error handling utilities inspired by
 [Thanos Coding Style Guide](https://thanos.io/contributing/coding-style-guide.md/#defers-don-t-forget-to-check-returned-errors)
-or [Uber go style guide](https://github.com/uber-go/guide/blob/master/style.md).
+and [Uber go style guide](https://github.com/uber-go/guide/blob/master/style.md).
 
 ## Closing Resources
 
-errorist provides resource management utilities for easily closing `io.Closer` with `defer`.
+errorist provides hassle-free functions closing `io.Closer` with `defer`.
 
 ### With Error Capture
 
-Most recommended way is using error capture. Error caused by `Close` will be captured on given `error` pointer
- if there's no error already present on it.
+The most recommended way is using error capture. An error caused by `Close` will be captured on the given `error` pointer
+ unless it already has an error as the value.
 
 ```go
 func printFile(path string) (err error) {
@@ -30,7 +30,7 @@ func printFile(path string) (err error) {
 
 ### With Error Channel
 
-Error also can be captured to error channel (`chan error`). It has a good fit with resources managed in goroutines.
+An error also can be captured and sent to an error channel (`chan error`). It is a good fit with resources in goroutines.
 
 ```go
 errChan := make(chan error)
@@ -43,7 +43,7 @@ go func() {
 
 ### With Error Log
 
-Otherwise, why can't we just log and ignore it? Default logger is `log.Println` but you can customize it with options.
+Otherwise, why don't we just log and ignore it? Default logger is `log.Println` but you are able to customize it with options.
 
 
 ```go
@@ -55,8 +55,8 @@ defer errorist.CloseWithLogOnErr(f, errorist.LogWithLogrus(logger.Warn))
 
 ### Adding Contexts with Error Wrapping
 
-If you're familiar with `errors.Wrap` or `fmt.Errorf`, you might want to do same thing on errors handling with errorist.
-errorist provides option for wrapping errors with context.
+If you're familiar with `errors.Wrap` or `fmt.Errorf`, you may want to do the same error handling with errorist.
+errorist provides the option wrapping errors with context.
 
 ```go
 func printFile(path string) (err error) {
@@ -69,13 +69,13 @@ func printFile(path string) (err error) {
 }
 ```
 
-> Note that `errorist.Wrapf` is just option specifier for errorist; it cannot be used solely.
-If you want to just wrap errors, you may use [pkg/errors](http://github.com/pkg/errors) or `fmt.Errorf` with `%w` pattern added in Go 1.13.
+> Note that `errorist.Wrapf` is just an option specifier for errorist; it cannot be used solely.
+If you want to just wrap errors, you can use [pkg/errors](http://github.com/pkg/errors) or `fmt.Errorf` with `%w` pattern added in Go 1.13.
 
 
 ## Recovering from Panics
 
-errorist provides panic recovery functions that can be used together with `defer`.
+errorist provides panic recovery functions that can be used with `defer`.
 
 ```go
 wg, ctx := errgroup.WithContext(context.Background())
@@ -85,7 +85,7 @@ wg.Go(func() (err error) {
 })
 ```
 
-Stacktrace is prettified and calls from non-project source will be filtered by default.
+Stacktrace is prettified, and calls from non-project source will be filtered by default.
 You can customize stacktrace format with options. For details, please refer
 [options.go](https://github.com/therne/errorist/blob/master/options.go).
 
@@ -102,10 +102,10 @@ panic: assignment to entry in nil map
     github.com/therne/errorist.TestWrapPanicWith (panic_test.go:11)
 ```
 
-## Prettifying Stacktraces on Error
+## Prettifying Stacktraces on Errors
 
-[pkg/errors](http://github.com/pkg/errors) is most popular and powerful tool for handling and wrapping errors.
-errorist provides extracting and prettifying a stacktrace from errors created and wrapped by pkg/errors.
+[pkg/errors](http://github.com/pkg/errors) is the most popular and powerful tool for handling and wrapping errors.
+errorist provides extracting and prettifying a stacktrace from errors created or wrapped by pkg/errors.
 
 ```go
 errorist.Stacktrace(err) ==
@@ -115,7 +115,7 @@ errorist.Stacktrace(err) ==
     }
 ```
 
-An example usecase is using it with API response for debugging errors.
+The below example shows how to use it in API responses for debugging purposes.
 
 ```go
 func handleGinError(c *gin.Context) {
@@ -132,7 +132,7 @@ func handleGinError(c *gin.Context) {
 
 ## Options
 
-You can apply options globally, package-wide, or with call arguments. Options set on smaller scope can override options set on wider scope.
+You can use global options, package-wide, or with call arguments. Options set on a smaller scope can override options set on a wider scope.
 
 ```go
 errorist.SetGlobalOptions(
@@ -150,6 +150,6 @@ errorist.SetPackageLevelOptions(
 errorist.CloseWithErrCapture(f, &err, errorist.Wrapf("close %s", path))
 ```
 
-For detailed options reference, please refer [Godoc](https://pkg.go.dev/github.com/therne/errorist?tab=doc#Options) or [options.go](https://github.com/therne/errorist/blob/master/options.go).
+For detailed options, please refer [Godoc](https://pkg.go.dev/github.com/therne/errorist?tab=doc#Options) or [options.go](https://github.com/therne/errorist/blob/master/options.go).
 
 ###### License: MIT

--- a/closer.go
+++ b/closer.go
@@ -12,7 +12,7 @@ func CloseWithErrCapture(c io.Closer, capture *error, opts ...Option) {
 	}
 }
 
-// CloseWithErrCapture is used if you want to close and fail the function or
+// CloseWithErrChan is used if you want to close and fail the function or
 // method on a `io.Closer.Close()` error (make sure the `error` return argument is
 // named as `err`). If the error is already present, `CloseWithErrChan`
 // will send the error to the given channel caused by `Close` if any.

--- a/options.go
+++ b/options.go
@@ -68,7 +68,7 @@ func WithDetailedTrace() Option {
 	}
 }
 
-// WithDetailedTrace is an option for including non-project files to stacktrace.
+// IncludeNonProjectFiles is an option for including non-project files to stacktrace.
 // It is not recommended to use this option for production because it refers
 // GOPATH from environment variable for the decision. IncludedPackages is recommended.
 func IncludeNonProjectFiles() Option {
@@ -113,7 +113,7 @@ func WithLogHandler(handler func(err string)) Option {
 	}
 }
 
-// SetPackageLevelOptions sets options applied in current package scope.
+// SetGlobalOptions sets options applied in current package scope.
 // It can override global options.
 func SetGlobalOptions(opts ...Option) {
 	globalOptions = opts

--- a/stacktrace.go
+++ b/stacktrace.go
@@ -18,9 +18,9 @@ type stackTracer interface {
 	StackTrace() errors.StackTrace
 }
 
-// Stacktrace returns pretty-formatted stack trace of errors created or wrapped by
-// `github.com/pkg/errors` library. Runtime stack traces are skipped for simplicity.
-func Stacktrace(err error, opt ...Option) (traceEntries []string) {
+// Stacktrace returns pretty-formatted stack trace of an error created or wrapped by
+// `github.com/pkg/errors` package. Runtime stack traces are skipped for simplicity.
+func Stacktrace(err error, _ ...Option) (traceEntries []string) {
 	tr, ok := err.(stackTracer)
 	if !ok {
 		return []string{callerTrace(1)}

--- a/stopper.go
+++ b/stopper.go
@@ -14,7 +14,7 @@ func StopWithErrCapture(c Stopper, capture *error, opts ...Option) {
 	}
 }
 
-// StopWithErrCapture is used if you want to Stop and fail the function or
+// StopWithErrChan is used if you want to Stop and fail the function or
 // method on a `Stop()` error (make sure the `error` return argument is
 // named as `err`). If the error is already present, `StopWithErrChan`
 // will send the error to the given channel caused by `Stop` if any.


### PR DESCRIPTION
* README 의 영어표현을 읽기 편하게 손봤습니다.
* 주석의 잘못된 함수명들을 고쳤습니다.